### PR TITLE
First non linear transform

### DIFF
--- a/transforms/transformPoint.glsl
+++ b/transforms/transformPoint.glsl
@@ -1,0 +1,10 @@
+vec3 transformPoint(const in vec3 samplePoint, const in float frequency, const in float amplitude)
+// Apply a spatial transformation to a world space point
+{
+  return samplePoint + amplitude * vec3(samplePoint.x * sin(frequency * samplePoint.z),
+                                        samplePoint.y * cos(frequency * samplePoint.z),
+                                        0);
+}
+
+// needed for glslify
+#pragma glslify: export(transformPoint)


### PR DESCRIPTION
Contains required GLSLIFY #pragma.
GLSLIFY doesn't support uniforms so all variables must be passed through the functions arguments.

Should we rename the file in a more meaningful way? (I couldn't come up with anything good)
